### PR TITLE
fix: filter invalid TSet values and correct OpenTherm f8.8 temperature decoding

### DIFF
--- a/Firmware/src/CHcontrol.cpp
+++ b/Firmware/src/CHcontrol.cpp
@@ -99,8 +99,13 @@ void CHcontrol::getJson(JsonObject &obj) {
 double CHcontrol::getFlow() {
     double result = config.flow;
 
-    if (overrideEnabled && ovrdTemp.active)
-        return ovrdTemp.value;
+    if (overrideEnabled && ovrdTemp.active) {
+        if (ovrdTemp.value <= 0)
+            return 0;
+        double v = ovrdTemp.value;
+        clip(v, flowMin, curve.getFlowMax());
+        return v;
+    }
 
     switch (mode) {
     case HADiscovery::MODE_HEAT:

--- a/Firmware/src/otcontrol.cpp
+++ b/Firmware/src/otcontrol.cpp
@@ -42,7 +42,7 @@ const struct {
     {Tret,                      floatToOT(41.7)},
     {TflowCH2,                  floatToOT(48.6)},
     {Tdhw2,                     floatToOT(37.6)},
-    {Texhaust,                  90},
+    {Texhaust,                  floatToOT(90.0)},
     {TrOverride2,               0},
     {TdhwSetUBTdhwSetLB,        nib(60, 40)}, // 60 °C upper bound, 40 C° lower bound
     {MaxTSetUBMaxTSetLB,        nib(60, 25)}, // 60 °C upper bound, 20 C° lower bound
@@ -709,17 +709,24 @@ void OTControl::OnRxSlave(const unsigned long msg, const OpenThermResponseStatus
             slave.sendResponse(resp, 'P');
 
             switch (id) {
-            case TSet:
-                chcontrol[0].ovrdTemp.value = OpenTherm::getFloat(msg);
-                if (chcontrol[0].ovrdTemp.active)
-                    setBoilerRequest[0].force();
+            case TSet: {
+                float val = OpenTherm::getFloat(msg);
+                if (val > 0) {
+                    chcontrol[0].ovrdTemp.value = val;
+                    if (chcontrol[0].ovrdTemp.active)
+                        setBoilerRequest[0].force();
+                }
                 break;
-
-            case TsetCH2:
-                chcontrol[1].ovrdTemp.value = OpenTherm::getFloat(msg);
-                if (chcontrol[1].ovrdTemp.active)
-                    setBoilerRequest[1].force();
+            }
+            case TsetCH2: {
+                float val = OpenTherm::getFloat(msg);
+                if (val > 0) {
+                    chcontrol[1].ovrdTemp.value = val;
+                    if (chcontrol[1].ovrdTemp.active)
+                        setBoilerRequest[1].force();
+                }
                 break;
+            }
 
             case TdhwSet:
                 dhwOvrd.temp = OpenTherm::getFloat(msg);

--- a/Firmware/src/otvalues.cpp
+++ b/Firmware/src/otvalues.cpp
@@ -108,7 +108,7 @@ OTValue *slaveValues[55] = { // replydata collected (read) from a connnected sla
     new OTValueFloatTemp(       Tdhw2,                                          PSTR("DHW temperature 2")),
     new OTValueFloatTemp(       Toutside,                                       PSTR("outside temp.")),
     new OTValueFloatTemp(       Tret,                                           PSTR("return temp.")),
-    new OTValuei16(             Texhaust,                   10,                 PSTR("exhaust temp.")),
+    new OTValueFloatTemp(       Texhaust,                                       PSTR("exhaust temp.")),
     new OTValueFloatTemp(       TrOverride2,                                    PSTR("room setpoint 2 override")),
     new OTValueProductVersion(  OpenThermVersionVentilationHeatRecovery,    0,  PSTR("OT-version slave")),
     new OTValueProductVersion(  VentilationHeatRecoveryVersion,             0,  PSTR("productversion slave")),
@@ -453,12 +453,7 @@ OTValueFloat::OTValueFloat(const OpenThermMessageID id, const int interval, PGM_
 
 void OTValueFloat::getValue(JsonVariant var) const {
     int8_t i = value >> 8;
-    double d;
-    if (i >= 0)
-        d = round((i + (value & 0xFF) / 256.0) * 10) / 10.0;
-    else
-        d = round((i - (value & 0xFF) / 256.0) * 10) / 10.0;
-
+    double d = round((i + (value & 0xFF) / 256.0) * 10) / 10.0;
     var.set<double>(d);
 }
 


### PR DESCRIPTION
wo verified bugs fixed affecting boiler control and temperature display:

[1] otcontrol.cpp / CHcontrol.cpp — Invalid TSet passthrough
Boilers like Thermona Therm 28 KDZ.A send TSet = 0xFE00 (-2.0°C) as
"heating circuit inactive" convention. Value was written unconditionally
to ovrdTemp.value before active-check, causing Otthing to forward -2°C
as CH setpoint. Boiler rejects invalid value and falls back to
self-regulation (80°C default).

Primary fix (otcontrol.cpp): reject TSet/TsetCH2 <= 0 at receive time
before storing in ovrdTemp.value.
Defensive fix (CHcontrol.cpp): add flowMin clamp in override path (PATH 1).
Returns 0 for negative values so getChOn() correctly disables CH.

[2] otvalues.cpp / otcontrol.cpp — f8.8 decoding errors
Three related issues:
- Texhaust (Data-ID 0x11) typed as OTValuei16, outputting raw uint16
  as integer. Raw 0x2299 displayed as 8857°C instead of 34.6°C.
  Fix: changed to OTValueFloatTemp.
- OTValueFloat::getValue() subtracted fractional byte for negative
  temperatures instead of adding it. -5.5°C displayed as -6.5°C,
  affecting outside temp and return temp in winter.
  Fix: always add fractional part regardless of sign.
- Loopback test value {Texhaust, 90} missing floatToOT() encoding.
  Would have decoded as 0.35°C after f8.8 fix.
  Fix: changed to floatToOT(90.0).

Reproducer:  DHW cycle active → boiler at 80°C.
exhaust_t showing implausible values (6476, 8857) in /status endpoint.