### PR TITLE
fix: clip negative TSet values from slave instead of ignoring them

### DIFF
--- a/Firmware/src/CHcontrol.cpp
+++ b/Firmware/src/CHcontrol.cpp
@@ -99,8 +99,11 @@ void CHcontrol::getJson(JsonObject &obj) {
 double CHcontrol::getFlow() {
     double result = config.flow;
 
-    if (overrideEnabled && ovrdTemp.active)
+    if (overrideEnabled && ovrdTemp.active) {
+        if (ovrdTemp.value <= 0)
+            return 0;
         return ovrdTemp.value;
+    }
 
     switch (mode) {
     case HADiscovery::MODE_HEAT:

--- a/Firmware/src/otcontrol.cpp
+++ b/Firmware/src/otcontrol.cpp
@@ -709,17 +709,22 @@ void OTControl::OnRxSlave(const unsigned long msg, const OpenThermResponseStatus
             slave.sendResponse(resp, 'P');
 
             switch (id) {
-            case TSet:
-                chcontrol[0].ovrdTemp.value = OpenTherm::getFloat(msg);
+            case TSet: {
+                float val = OpenTherm::getFloat(msg);
+                if (val < 0) val = 0;
+                chcontrol[0].ovrdTemp.value = val;
                 if (chcontrol[0].ovrdTemp.active)
                     setBoilerRequest[0].force();
                 break;
-
-            case TsetCH2:
-                chcontrol[1].ovrdTemp.value = OpenTherm::getFloat(msg);
+            }
+            case TsetCH2: {
+                float val = OpenTherm::getFloat(msg);
+                if (val < 0) val = 0;
+                chcontrol[1].ovrdTemp.value = val;
                 if (chcontrol[1].ovrdTemp.active)
                     setBoilerRequest[1].force();
                 break;
+            }
 
             case TdhwSet:
                 dhwOvrd.temp = OpenTherm::getFloat(msg);


### PR DESCRIPTION
The Boiler send TSet = 0xFE00 (-2.0f) as
"heating circuit inactive" convention. Value was written unconditionally
to ovrdTemp.value, causing Otthing to forward -2°C as CH setpoint.
Boiler rejects the invalid value and falls back to self-regulation (80°C).

otcontrol.cpp: clip val to 0 if val < 0 before storing in ovrdTemp.value.
CHcontrol.cpp: return 0 in override path if ovrdTemp.value <= 0 so
getChOn() correctly disables CH. No flowMin clip per design — override
intentionally passes full responsibility to the room unit.