### PR TITLE
fix: correct f8.8 negative temperature decoding; configurable exhaust

### DIFF
--- a/Firmware/data/index.html
+++ b/Firmware/data/index.html
@@ -2503,6 +2503,13 @@
                                 <span class="slider"></span>
                             </label>
                         </div>
+                        <div class="param">
+                            <h5>Exhaust (non-std.)</h5>
+                            <label class="switch">
+                                <input type="checkbox" field="boiler.texhaustAsFloat" />
+                                <span class="slider"></span>
+                            </label>
+                        </div>
                     </div>
                     <div class="flexline">
                         <div class="param range" field="boiler.maxModulation">
@@ -2846,7 +2853,8 @@
                 otc: false,
                 summerMode: false,
                 dhwBlocking: false,
-                maxModulation: 100
+                maxModulation: 100,
+                texhaustAsFloat: false
             },
             heating: [
                 {

--- a/Firmware/include/otvalues.h
+++ b/Firmware/include/otvalues.h
@@ -167,6 +167,7 @@ public:
     static OTValue* getSlaveValue(const OpenThermMessageID id);
     static OTValue* getMasterValue(const OpenThermMessageID id);
     static class OTValueSlaveConfigMember* getSlaveConfig();
+    static void setTexhaustAsFloat(bool asFloat);
     void refreshDisc();
     bool isSet() const;
     bool hasReply() const;

--- a/Firmware/src/otcontrol.cpp
+++ b/Firmware/src/otcontrol.cpp
@@ -1263,6 +1263,7 @@ void OTControl::setConfig(JsonObject &config) {
     boilerConfig.otc = boiler[F("otc")] | false;
     boilerConfig.summerMode = boiler[F("summerMode")] | false;
     boilerConfig.dhwBlocking = boiler[F("dhwBlocking")] | false;
+    OTValue::setTexhaustAsFloat(boiler[F("texhaustAsFloat")] | false);
 
     masterMemberId = config[F("masterMemberId")] | 22;
 

--- a/Firmware/src/otvalues.cpp
+++ b/Firmware/src/otvalues.cpp
@@ -211,6 +211,22 @@ OTValueSlaveConfigMember* OTValue::getSlaveConfig() {
     return static_cast<OTValueSlaveConfigMember*>(getSlaveValue(SConfigSMemberIDcode));
 }
 
+void OTValue::setTexhaustAsFloat(const bool asFloat) {
+    static bool current = false;
+    if (asFloat == current)
+        return;
+    current = asFloat;
+    for (auto *&val: slaveValues) {
+        if (val->id == Texhaust) {
+            delete val;
+            val = asFloat
+                ? (OTValue*) new OTValueFloatTemp(Texhaust,      PSTR("exhaust temp."))
+                : (OTValue*) new OTValuei16(      Texhaust, 10,  PSTR("exhaust temp."));
+            return;
+        }
+    }
+}
+
 OTValue* OTValue::getMasterValue(const OpenThermMessageID id) {
     for (auto *val: masterValues) {
         if (val->id == id) {
@@ -451,13 +467,7 @@ OTValueFloat::OTValueFloat(const OpenThermMessageID id, const int interval, PGM_
 }
 
 void OTValueFloat::getValue(JsonVariant var) const {
-    int8_t i = value >> 8;
-    double d;
-    if (i >= 0)
-        d = round((i + (value & 0xFF) / 256.0) * 10) / 10.0;
-    else
-        d = round((i - (value & 0xFF) / 256.0) * 10) / 10.0;
-
+    double d = round((int16_t)value * 10 / 256.0) / 10.0;
     var.set<double>(d);
 }
 


### PR DESCRIPTION
Per OT-Spec, Texhaust (0x21) is s16 — raw value equals °C directly.
Some boilers (e.g. Thermona ) send exhaust temperature as f8.8 float against spec.
Adds a "Exhaust (non-std.)" toggle in the boiler settings UI (boiler.texhaustAsFloat, default: false).
When enabled, the Texhaust entry is switched from OTValuei16 to OTValueFloatTemp at runtime.

Default behaviour (spec-compliant s16) is unchanged.