### PR TITLE
Add "heating demand" aux input mode to drive CH on/off from a volt-free contact

### DIFF
--- a/Firmware/data/index.html
+++ b/Firmware/data/index.html
@@ -2984,6 +2984,7 @@
                             <option value="1">digital</option>
                             <option value="3">analog</option>
                             <option value="4">1wire</option>
+                            <option value="5">heating demand</option>
                         </select>
                     </div>
                     <div class="param">
@@ -2992,6 +2993,7 @@
                             <option value="0">unused</option>
                             <option value="1">digital</option>
                             <option value="4">1wire</option>
+                            <option value="5">heating demand</option>
                         </select>
                     </div>
                 </div>

--- a/Firmware/data/index.html
+++ b/Firmware/data/index.html
@@ -2979,22 +2979,40 @@
                 <div class="flexline">
                     <div class="param">
                         <h5>aux 1 (DQ)</h5>
-                        <select field="aux.0.mode" intval>
+                        <select id="aux0mode" field="aux.0.mode" intval>
                             <option value="0">unused</option>
                             <option value="1">digital</option>
                             <option value="3">analog</option>
                             <option value="4">1wire</option>
-                            <option value="5">heating demand</option>
                         </select>
+                        <div id="aux0role" hidden>
+                            <h5>role</h5>
+                            <select field="aux.0.digitalRole" intval>
+                                <option value="0">none</option>
+                                <option value="1">demand CH 1</option>
+                                <option value="2">demand CH 2</option>
+                                <option value="3">enable CH 1</option>
+                                <option value="4">enable CH 2</option>
+                            </select>
+                        </div>
                     </div>
                     <div class="param">
                         <h5>aux. 2 (DI)</h5>
-                        <select field="aux.1.mode" intval>
+                        <select id="aux1mode" field="aux.1.mode" intval>
                             <option value="0">unused</option>
                             <option value="1">digital</option>
                             <option value="4">1wire</option>
-                            <option value="5">heating demand</option>
                         </select>
+                        <div id="aux1role" hidden>
+                            <h5>role</h5>
+                            <select field="aux.1.digitalRole" intval>
+                                <option value="0">none</option>
+                                <option value="1">demand CH 1</option>
+                                <option value="2">demand CH 2</option>
+                                <option value="3">enable CH 1</option>
+                                <option value="4">enable CH 2</option>
+                            </select>
+                        </div>
                     </div>
                 </div>
                 
@@ -3202,10 +3220,12 @@
             masterMemberId: 8,
             aux: [
                 {
-                    mode: 4 // 1wire
+                    mode: 4, // 1wire
+                    digitalRole: 0
                 },
                 {
-                    mode: 0 // not used
+                    mode: 0, // not used
+                    digitalRole: 0
                 }
             ]
         };
@@ -5355,6 +5375,17 @@
                 });
             }
 
+            function updateAuxRoleVisibility(idx, mode) {
+                const roleDiv = _(`#aux${idx}role`);
+                if (roleDiv) roleDiv.hidden = (parseInt(mode) !== 1);
+            }
+            [0, 1].forEach(idx => {
+                const sel = _(`#aux${idx}mode`);
+                if (sel) {
+                    sel.addEventListener("change", (ev) => updateAuxRoleVisibility(idx, ev.target.value));
+                }
+            });
+
             window.drawMarkerTable = function drawMarkerTable() {
                 _("#markerbody").innerHTML = "";
                 const markers = config.heating[currentCh].marker ?? [];
@@ -5531,6 +5562,7 @@
                 _("#curveMode").dispatchEvent(new Event("change"));
 
                 updateOtModeVisibility(getConfigValFromPath("otMode"));
+                [0, 1].forEach(idx => updateAuxRoleVisibility(idx, getConfigValFromPath(`aux.${idx}.mode`)));
 
                 drawMarkerTable();
                 drawCurve();

--- a/Firmware/include/CHcontrol.h
+++ b/Firmware/include/CHcontrol.h
@@ -15,6 +15,7 @@ public:
 class CHcontrol {
 private:
     bool roomCompEnabled() const;
+    bool calcChOn();
     const uint8_t channel;
     struct {
         double roomSet; // default room set point
@@ -66,5 +67,8 @@ public:
     ChannelOverride<bool> ovrdOn;
     ChannelOverride<double> ovrdTemp;
     HADiscovery::ClimateMode mode {HADiscovery::MODE_AUTO};
-    static bool overrideEnabled; // set if otMode is master
+    static bool overrideEnabled; // set if otMode is master && enableSlave
+    bool auxDemandOn {false};    // demand role: contact closed → force CH on (OR)
+    bool auxEnableActive {false};// enable role is configured for this channel
+    bool auxEnableOn {true};     // enable role: contact state (true = allow CH)
 };

--- a/Firmware/include/auxInput.h
+++ b/Firmware/include/auxInput.h
@@ -16,14 +16,21 @@ public:
         MODE_COUNTER = 2,
         MODE_ANALOG = 3,
         MODE_1WIRE = 4,
-        MODE_CH_DEMAND = 5   // digital input drives central heating on/off
     } mode;
+    enum DigitalRole {
+        DROLE_NONE = 0,
+        DROLE_DEMAND_CH1 = 1,  // contact closed OR-s into CH1 enable
+        DROLE_DEMAND_CH2 = 2,  // contact closed OR-s into CH2 enable
+        DROLE_ENABLE_CH1 = 3,  // contact state AND-s with CH1 enable
+        DROLE_ENABLE_CH2 = 4,  // contact state AND-s with CH2 enable
+    } digitalRole;
 
     void setup();
     void loop();
     void setConfig(JsonObject cfg);
     void getJson(JsonDocument &doc) const;
     bool sendDiscovery();
+    static bool hasEnableRole(uint8_t channel);
 };
 
 extern AuxInput auxInput[2];

--- a/Firmware/include/auxInput.h
+++ b/Firmware/include/auxInput.h
@@ -15,7 +15,8 @@ public:
         MODE_BINARY = 1,
         MODE_COUNTER = 2,
         MODE_ANALOG = 3,
-        MODE_1WIRE = 4
+        MODE_1WIRE = 4,
+        MODE_CH_DEMAND = 5   // digital input drives central heating on/off
     } mode;
 
     void setup();

--- a/Firmware/include/otcontrol.h
+++ b/Firmware/include/otcontrol.h
@@ -136,7 +136,8 @@ public:
     void setVentSetpoint(const uint8_t v);
     void setVentEnable(const bool en);
     void setOverrideChOn(const bool ovrd, const uint8_t channel);
-    void setChDemand(const bool on, const uint8_t channel = 0);
+    void setAuxDemand(const uint8_t channel, const bool on);
+    void setAuxEnable(const uint8_t channel, const bool on);
     void setOverrideChFlow(const bool ovrd, const uint8_t channel);
     void setOverrideDhw(const bool ovrd);
     void setMaxMod(const int mm);

--- a/Firmware/include/otcontrol.h
+++ b/Firmware/include/otcontrol.h
@@ -136,6 +136,7 @@ public:
     void setVentSetpoint(const uint8_t v);
     void setVentEnable(const bool en);
     void setOverrideChOn(const bool ovrd, const uint8_t channel);
+    void setChDemand(const bool on, const uint8_t channel = 0);
     void setOverrideChFlow(const bool ovrd, const uint8_t channel);
     void setOverrideDhw(const bool ovrd);
     void setMaxMod(const int mm);

--- a/Firmware/src/CHcontrol.cpp
+++ b/Firmware/src/CHcontrol.cpp
@@ -163,7 +163,7 @@ double CHcontrol::getFlow() {
     return result;
 }
 
-bool CHcontrol::getChOn() {
+bool CHcontrol::calcChOn() {
     if (overrideEnabled && ovrdOn.active)
         return ovrdOn.value;
 
@@ -180,6 +180,13 @@ bool CHcontrol::getChOn() {
         return false;
 
     return true;
+}
+
+bool CHcontrol::getChOn() {
+    bool on = calcChOn();
+    if (auxEnableActive) on = on && auxEnableOn;   // AND: enable role gates CH
+    if (auxDemandOn)     on = on || auxDemandOn;   // OR: demand role forces CH on
+    return on;
 }
 
 void CHcontrol::setMode(const HADiscovery::ClimateMode mode) {

--- a/Firmware/src/auxInput.cpp
+++ b/Firmware/src/auxInput.cpp
@@ -1,5 +1,6 @@
 #include "auxInput.h"
 #include <Arduino.h>
+#include "otcontrol.h"
 #include "HADiscLocal.h"
 #include "sensors.h"
 #include "hwdef.h"
@@ -26,6 +27,11 @@ void AuxInput::setConfig(JsonObject cfg) {
         state = digitalRead(gpio) == 0;
         break;
 
+    case MODE_CH_DEMAND:
+        pinMode(gpio, INPUT);
+        state = !(digitalRead(gpio) == 0); // opposite so first loop() always syncs
+        break;
+
     case MODE_ANALOG:
         pinMode(gpio, ANALOG);
         analogSetAttenuation(ADC_11db);
@@ -41,11 +47,19 @@ void AuxInput::setConfig(JsonObject cfg) {
 }
 
 void AuxInput::loop() {
+    if (mode != MODE_CH_DEMAND)
+        return;
+    bool now = (digitalRead(gpio) == 0);
+    if (now != state) {
+        state = now;
+        otcontrol.setChDemand(state);
+    }
 }
 
 void AuxInput::getJson(JsonDocument &doc) const {
     JsonObject obj = doc[FPSTR(name)].to<JsonObject>();
     switch (mode) {
+    case MODE_CH_DEMAND:
     case MODE_BINARY:
         obj[F("state")] = digitalRead(gpio) == 0;
         break;
@@ -59,6 +73,13 @@ void AuxInput::getJson(JsonDocument &doc) const {
 
 bool AuxInput::sendDiscovery() {
     switch (mode) {
+    case MODE_CH_DEMAND: {
+        haDisc.createBinarySensor(F("heating demand"), FPSTR(name), "");
+        String str = F("{% set tmp=(value_json.get('#') or {}).get('state') %}{{ none if tmp is none else 'ON' if tmp else 'OFF' }}");
+        str.replace("#", FPSTR(name));
+        haDisc.setValueTemplate(str);
+        return haDisc.publish();
+    }
     case MODE_BINARY: {
         haDisc.createBinarySensor(F("digital input"), FPSTR(name), "");
         String str = F("{% set tmp=(value_json.get('#') or {}).get('state') %}{{ none if tmp is none else 'ON' if tmp else 'OFF' }}");

--- a/Firmware/src/auxInput.cpp
+++ b/Firmware/src/auxInput.cpp
@@ -11,25 +11,28 @@ AuxInput auxInput[2] = {
 };
 
 AuxInput::AuxInput(const char *name, const uint8_t gpio):
-    state(false),    
+    state(false),
     name(name),
     gpio(gpio),
-    mode(MODE_UNUSED) {
+    mode(MODE_UNUSED),
+    digitalRole(DROLE_NONE) {
 }
 
 void AuxInput::setConfig(JsonObject cfg) {
     mode = (Mode) (cfg[F("mode")] | MODE_UNUSED);
+    digitalRole = DROLE_NONE;
 
     switch (mode) {
     case MODE_BINARY:
+        digitalRole = (DigitalRole) (cfg[F("digitalRole")] | DROLE_NONE);
+        pinMode(gpio, INPUT);
+        // Invert initial state so first loop() always syncs the role state
+        state = (digitalRole != DROLE_NONE) ? !(digitalRead(gpio) == 0) : (digitalRead(gpio) == 0);
+        break;
+
     case MODE_COUNTER:
         pinMode(gpio, INPUT);
         state = digitalRead(gpio) == 0;
-        break;
-
-    case MODE_CH_DEMAND:
-        pinMode(gpio, INPUT);
-        state = !(digitalRead(gpio) == 0); // opposite so first loop() always syncs
         break;
 
     case MODE_ANALOG:
@@ -47,19 +50,22 @@ void AuxInput::setConfig(JsonObject cfg) {
 }
 
 void AuxInput::loop() {
-    if (mode != MODE_CH_DEMAND)
+    if (mode != MODE_BINARY || digitalRole == DROLE_NONE)
         return;
     bool now = (digitalRead(gpio) == 0);
-    if (now != state) {
-        state = now;
-        otcontrol.setChDemand(state);
-    }
+    if (now == state)
+        return;
+    state = now;
+    uint8_t ch = (digitalRole == DROLE_DEMAND_CH2 || digitalRole == DROLE_ENABLE_CH2) ? 1 : 0;
+    if (digitalRole == DROLE_ENABLE_CH1 || digitalRole == DROLE_ENABLE_CH2)
+        otcontrol.setAuxEnable(ch, state);
+    else
+        otcontrol.setAuxDemand(ch, state);
 }
 
 void AuxInput::getJson(JsonDocument &doc) const {
     JsonObject obj = doc[FPSTR(name)].to<JsonObject>();
     switch (mode) {
-    case MODE_CH_DEMAND:
     case MODE_BINARY:
         obj[F("state")] = digitalRead(gpio) == 0;
         break;
@@ -73,15 +79,10 @@ void AuxInput::getJson(JsonDocument &doc) const {
 
 bool AuxInput::sendDiscovery() {
     switch (mode) {
-    case MODE_CH_DEMAND: {
-        haDisc.createBinarySensor(F("heating demand"), FPSTR(name), "");
-        String str = F("{% set tmp=(value_json.get('#') or {}).get('state') %}{{ none if tmp is none else 'ON' if tmp else 'OFF' }}");
-        str.replace("#", FPSTR(name));
-        haDisc.setValueTemplate(str);
-        return haDisc.publish();
-    }
     case MODE_BINARY: {
-        haDisc.createBinarySensor(F("digital input"), FPSTR(name), "");
+        const __FlashStringHelper *label = (digitalRole != DROLE_NONE)
+            ? F("heating demand") : F("digital input");
+        haDisc.createBinarySensor(label, FPSTR(name), "");
         String str = F("{% set tmp=(value_json.get('#') or {}).get('state') %}{{ none if tmp is none else 'ON' if tmp else 'OFF' }}");
         str.replace("#", FPSTR(name));
         haDisc.setValueTemplate(str);
@@ -102,4 +103,12 @@ bool AuxInput::sendDiscovery() {
         break;
     }
     return true;
+}
+
+bool AuxInput::hasEnableRole(uint8_t channel) {
+    DigitalRole target = (channel == 0) ? DROLE_ENABLE_CH1 : DROLE_ENABLE_CH2;
+    for (const auto& a : auxInput)
+        if (a.mode == MODE_BINARY && a.digitalRole == target)
+            return true;
+    return false;
 }

--- a/Firmware/src/otcontrol.cpp
+++ b/Firmware/src/otcontrol.cpp
@@ -1,5 +1,6 @@
 #include <WiFi.h>
 #include "otcontrol.h"
+#include "auxInput.h"
 #include "otvalues.h"
 #include "command.h"
 #include "HADiscLocal.h"
@@ -241,7 +242,9 @@ uint16_t OTControl::tmpToData(const double tmpf) {
 void OTControl::setOTMode(const OTMode mode) {
     otMode = mode;
 
-    CHcontrol::overrideEnabled = (otMode == OTMODE_MASTER) && enableSlave;
+    bool auxChDemand = (auxInput[0].mode == AuxInput::MODE_CH_DEMAND) ||
+                       (auxInput[1].mode == AuxInput::MODE_CH_DEMAND);
+    CHcontrol::overrideEnabled = (otMode == OTMODE_MASTER) && (enableSlave || auxChDemand);
 
     // set bypass relay
     digitalWrite(GPIO_BYPASS_RELAY, (mode != OTMODE_BYPASS) && !bypass);
@@ -1309,6 +1312,13 @@ void OTControl::setConfig(JsonObject &config) {
         discFlag = false;
     }
 
+    // recompute overrideEnabled in case only aux mode changed (no OT mode/slave change)
+    {
+        bool auxChDemand = (auxInput[0].mode == AuxInput::MODE_CH_DEMAND) ||
+                           (auxInput[1].mode == AuxInput::MODE_CH_DEMAND);
+        CHcontrol::overrideEnabled = (otMode == OTMODE_MASTER) && (enableSlave || auxChDemand);
+    }
+
     for (int i=0; i<NUM_HEATCIRCUITS; i++) {
         JsonObject obj = config[F("heating")][i];
         chcontrol[i].setConfig(obj, init);
@@ -1368,6 +1378,11 @@ void OTControl::setChCtrlMode(const HADiscovery::ClimateMode mode, const uint8_t
 void OTControl::setOverrideChOn(const bool ovrd, const uint8_t channel) {
     chcontrol[channel].ovrdOn.active = ovrd;
     setBoilerRequest[channel].force();
+}
+
+void OTControl::setChDemand(const bool on, const uint8_t channel) {
+    chcontrol[channel].ovrdOn.active = true;
+    chcontrol[channel].ovrdOn.value = on;
 }
 
 void OTControl::setOverrideChFlow(const bool ovrd, const uint8_t channel) {

--- a/Firmware/src/otcontrol.cpp
+++ b/Firmware/src/otcontrol.cpp
@@ -242,9 +242,16 @@ uint16_t OTControl::tmpToData(const double tmpf) {
 void OTControl::setOTMode(const OTMode mode) {
     otMode = mode;
 
-    bool auxChDemand = (auxInput[0].mode == AuxInput::MODE_CH_DEMAND) ||
-                       (auxInput[1].mode == AuxInput::MODE_CH_DEMAND);
-    CHcontrol::overrideEnabled = (otMode == OTMODE_MASTER) && (enableSlave || auxChDemand);
+    CHcontrol::overrideEnabled = (otMode == OTMODE_MASTER) && enableSlave;
+
+    // Reset aux CH role state when leaving master mode
+    if (otMode != OTMODE_MASTER) {
+        for (auto& ch : chcontrol) {
+            ch.auxDemandOn = false;
+            ch.auxEnableActive = false;
+            ch.auxEnableOn = true;
+        }
+    }
 
     // set bypass relay
     digitalWrite(GPIO_BYPASS_RELAY, (mode != OTMODE_BYPASS) && !bypass);
@@ -1312,11 +1319,13 @@ void OTControl::setConfig(JsonObject &config) {
         discFlag = false;
     }
 
-    // recompute overrideEnabled in case only aux mode changed (no OT mode/slave change)
-    {
-        bool auxChDemand = (auxInput[0].mode == AuxInput::MODE_CH_DEMAND) ||
-                           (auxInput[1].mode == AuxInput::MODE_CH_DEMAND);
-        CHcontrol::overrideEnabled = (otMode == OTMODE_MASTER) && (enableSlave || auxChDemand);
+    // Sync aux CH role flags into CHcontrol (only meaningful in master mode)
+    if (otMode == OTMODE_MASTER) {
+        for (int i = 0; i < NUM_HEATCIRCUITS; i++) {
+            chcontrol[i].auxDemandOn = false;  // reset; loop() will resync on next edge
+            chcontrol[i].auxEnableOn = true;   // safe default: allow CH
+            chcontrol[i].auxEnableActive = AuxInput::hasEnableRole(i);
+        }
     }
 
     for (int i=0; i<NUM_HEATCIRCUITS; i++) {
@@ -1380,9 +1389,14 @@ void OTControl::setOverrideChOn(const bool ovrd, const uint8_t channel) {
     setBoilerRequest[channel].force();
 }
 
-void OTControl::setChDemand(const bool on, const uint8_t channel) {
-    chcontrol[channel].ovrdOn.active = true;
-    chcontrol[channel].ovrdOn.value = on;
+void OTControl::setAuxDemand(const uint8_t channel, const bool on) {
+    if (otMode != OTMODE_MASTER) return;
+    chcontrol[channel].auxDemandOn = on;
+}
+
+void OTControl::setAuxEnable(const uint8_t channel, const bool on) {
+    if (otMode != OTMODE_MASTER) return;
+    chcontrol[channel].auxEnableOn = on;
 }
 
 void OTControl::setOverrideChFlow(const bool ovrd, const uint8_t channel) {


### PR DESCRIPTION
## Summary
Adds a new auxiliary-input mode, `heating demand` (MODE_CH_DEMAND), that lets a volt-free external contact on the digital input (AUX 2 / GPIO_AUX_IN) drive the boiler's central-heating enable directly on-device, with no external automation. Closed contact → CH ON; open → CH OFF. Flow temperature still follows the existing heating curve/setpoint; only the CH on/off state is overridden.

## Motivation
Systems that delegate zone logic to an external wiring centre/manifold (e.g. underfloor-heating controllers) expose a single volt-free "call for heat" relay. Today the digital aux input is only published to Home Assistant as a binary_sensor and is never referenced by CHcontrol/OTControl, so it cannot gate CH; the sensor-source enum has no "digital" option either. The only workaround is an external automation, which makes the basic "burn when a zone asks" behaviour depend on the broker/controller being online. This PR wires the digital input into the existing CHcontrol override so the demand contact drives CH autonomously.

## Implementation
- include/auxInput.h: new enum value MODE_CH_DEMAND.
- src/auxInput.cpp: input configured as INPUT; previously-empty loop() forwards contact edges to OTControl::setChDemand(); still exposed to HA as a binary_sensor.
- include/otcontrol.h + src/otcontrol.cpp: new public setChDemand() sets chcontrol[channel].ovrdOn (active+value), keeping chcontrol[] encapsulated. setOTMode() now opens the override gate when an aux input is in CH-demand mode (enableSlave || auxChDemand), so the slave interface and its +24V step-up stay off (GPIO_STEPUP_ENABLE unchanged).
- data/index.html: adds the "heating demand" option to the aux-input selector.
getChOn() already feeds the OT MasterStatus CH_ENABLE bit, so no change is needed there.

## Behavior
With AUX 2 = heating demand and OT mode = Master: closed contact asserts CH_ENABLE within one polling cycle (~1s); open clears it. DHW, modulation, return-limit and the heating curve are unaffected. Slave port stays unpowered unless "Enable slave interface" is separately on.

## Backward compatibility
Additive only. Existing modes unchanged; overrideEnabled change only adds an OR condition; config schema unchanged.

## Testing
Built for esp32-c3-devkitm-1 (pio run). Bench test (Master, AUX2=heating demand, no room unit): shorting DI–GND asserts CH_ENABLE and flow follows the curve; opening clears it; binary_sensor mirrors the contact in HA; slave port/+24V step-up stay off. Existing modes verified unaffected.

## Possible follow-ups
Optional input debounce; selectable target channel (currently CH1); mirror on AUX 1 where hardware permits.
